### PR TITLE
fix: use local timezone date for daily mock keys

### DIFF
--- a/mobile/src/lib/mock-store.ts
+++ b/mobile/src/lib/mock-store.ts
@@ -94,7 +94,11 @@ function generateId(): string {
 
 // Helper to get today's date string
 export function getLocalDate(): string {
-  return new Date().toISOString().split('T')[0];
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 // Format seconds to human readable


### PR DESCRIPTION
## Summary
- change mock date key generation from UTC-based ISO string to local timezone date
- avoid day-boundary mismatch for daily violation idempotency and reset behavior
- ## Validation
- npm --prefix mobile run typecheck