### PR TITLE
feat: add local warning notifications with iOS permission flow

### DIFF
--- a/mobile/__tests__/App.test.tsx
+++ b/mobile/__tests__/App.test.tsx
@@ -9,6 +9,11 @@ jest.mock('../src/navigation/AppNavigator', () => ({
   AppNavigator: () => null,
 }));
 
+jest.mock('../src/lib/usage-warning-notifier', () => ({
+  requestPermission: jest.fn().mockResolvedValue(true),
+  notifyIfThresholdReached: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('../src/lib/supabase', () => ({
   supabase: {
     auth: {

--- a/mobile/__tests__/app-context.notifications.test.tsx
+++ b/mobile/__tests__/app-context.notifications.test.tsx
@@ -42,8 +42,13 @@ jest.mock('../src/lib/supabase', () => ({
 }));
 
 function UsageSimulationHarness() {
-  const { profile, grantPermission, setSelectedApps, createContract, simulateUsage } =
-    useApp();
+  const {
+    profile,
+    grantPermission,
+    setSelectedApps,
+    createContract,
+    simulateUsage,
+  } = useApp();
   const didRunRef = useRef(false);
 
   useEffect(() => {
@@ -57,7 +62,13 @@ function UsageSimulationHarness() {
     setSelectedApps([app]);
     createContract(3600);
     simulateUsage(app.bundleId, 1800);
-  }, [profile, grantPermission, setSelectedApps, createContract, simulateUsage]);
+  }, [
+    profile,
+    grantPermission,
+    setSelectedApps,
+    createContract,
+    simulateUsage,
+  ]);
 
   return null;
 }

--- a/mobile/__tests__/app-context.notifications.test.tsx
+++ b/mobile/__tests__/app-context.notifications.test.tsx
@@ -14,7 +14,16 @@ jest.mock('../src/lib/supabase', () => ({
     auth: {
       getSession: jest
         .fn()
-        .mockResolvedValue({ data: { session: null }, error: null }),
+        .mockResolvedValueOnce({ data: { session: null }, error: null })
+        .mockResolvedValue({
+          data: {
+            session: {
+              access_token: 'test-access-token',
+              user: { id: 'test-user-id' },
+            },
+          },
+          error: null,
+        }),
       signInAnonymously: jest.fn().mockResolvedValue({
         data: { session: { user: { id: 'test-user-id' } } },
         error: null,
@@ -45,30 +54,36 @@ function UsageSimulationHarness() {
   const {
     profile,
     grantPermission,
+    selectedApps,
     setSelectedApps,
     createContract,
     simulateUsage,
   } = useApp();
-  const didRunRef = useRef(false);
+  const didSelectRef = useRef(false);
+  const didSimulateRef = useRef(false);
 
   useEffect(() => {
-    if (!profile || didRunRef.current) {
+    if (!profile || didSelectRef.current) {
       return;
     }
-    didRunRef.current = true;
+    didSelectRef.current = true;
 
     const app = MOCK_APP_CATALOG[0];
     grantPermission();
     setSelectedApps([app]);
-    createContract(3600);
-    simulateUsage(app.bundleId, 1800);
-  }, [
-    profile,
-    grantPermission,
-    setSelectedApps,
-    createContract,
-    simulateUsage,
-  ]);
+  }, [profile, grantPermission, setSelectedApps]);
+
+  useEffect(() => {
+    if (!profile || selectedApps.length === 0 || didSimulateRef.current) {
+      return;
+    }
+    didSimulateRef.current = true;
+
+    const app = selectedApps[0];
+    void createContract(3600).then(() => {
+      simulateUsage(app.bundleId, 1800);
+    });
+  }, [profile, selectedApps, setSelectedApps, createContract, simulateUsage]);
 
   return null;
 }
@@ -81,6 +96,20 @@ describe('AppContext notifications', () => {
   beforeEach(() => {
     mockStore.logout();
     jest.clearAllMocks();
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        contract: {
+          id: 'contract-1',
+          startAt: '2026-02-20T00:00:00.000Z',
+          endAt: '2026-02-27T00:00:00.000Z',
+          dailyLimitSeconds: 3600,
+          depositTotal: 3500,
+          status: 'active',
+          selectedApps: [MOCK_APP_CATALOG[0]],
+        },
+      }),
+    }) as unknown as typeof fetch;
   });
 
   it('calls notifier from simulateUsage flow', async () => {

--- a/mobile/__tests__/app-context.notifications.test.tsx
+++ b/mobile/__tests__/app-context.notifications.test.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useRef } from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+import { AppProvider, useApp } from '../src/lib/app-context';
+import { MOCK_APP_CATALOG, mockStore } from '../src/lib/mock-store';
+import { notifyIfThresholdReached } from '../src/lib/usage-warning-notifier';
+
+jest.mock('../src/lib/usage-warning-notifier', () => ({
+  requestPermission: jest.fn().mockResolvedValue(true),
+  notifyIfThresholdReached: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: null }, error: null }),
+      signInAnonymously: jest.fn().mockResolvedValue({
+        data: { session: { user: { id: 'test-user-id' } } },
+        error: null,
+      }),
+      signOut: jest.fn().mockResolvedValue({ error: null }),
+    },
+    from: jest.fn(() => ({
+      upsert: jest.fn().mockResolvedValue({ error: null }),
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: {
+              id: 'test-user-id',
+              apple_user_id: null,
+              stripe_customer_id: null,
+              created_at: '2026-01-01T00:00:00.000Z',
+              updated_at: '2026-01-01T00:00:00.000Z',
+            },
+            error: null,
+          }),
+        })),
+      })),
+    })),
+  },
+}));
+
+function UsageSimulationHarness() {
+  const { profile, grantPermission, setSelectedApps, createContract, simulateUsage } =
+    useApp();
+  const didRunRef = useRef(false);
+
+  useEffect(() => {
+    if (!profile || didRunRef.current) {
+      return;
+    }
+    didRunRef.current = true;
+
+    const app = MOCK_APP_CATALOG[0];
+    grantPermission();
+    setSelectedApps([app]);
+    createContract(3600);
+    simulateUsage(app.bundleId, 1800);
+  }, [profile, grantPermission, setSelectedApps, createContract, simulateUsage]);
+
+  return null;
+}
+
+async function flush(): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+describe('AppContext notifications', () => {
+  beforeEach(() => {
+    mockStore.logout();
+    jest.clearAllMocks();
+  });
+
+  it('calls notifier from simulateUsage flow', async () => {
+    await ReactTestRenderer.act(async () => {
+      ReactTestRenderer.create(
+        <AppProvider>
+          <UsageSimulationHarness />
+        </AppProvider>,
+      );
+      await flush();
+      await flush();
+      await flush();
+    });
+
+    expect(notifyIfThresholdReached).toHaveBeenCalledTimes(1);
+    expect(notifyIfThresholdReached).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localDate: expect.any(String),
+        usageSeconds: 1800,
+        dailyLimitSeconds: 3600,
+      }),
+    );
+  });
+});

--- a/mobile/__tests__/usage-warning-notifier.test.ts
+++ b/mobile/__tests__/usage-warning-notifier.test.ts
@@ -1,0 +1,127 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import {
+  notifyIfThresholdReached,
+  requestPermission,
+} from '../src/lib/usage-warning-notifier';
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+jest.mock('@react-native-community/push-notification-ios', () => ({
+  requestPermissions: jest.fn(),
+  addNotificationRequest: jest.fn(),
+}));
+
+describe('usage-warning-notifier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns permission result when requesting notification permission', async () => {
+    (PushNotificationIOS.requestPermissions as jest.Mock).mockResolvedValue({
+      alert: true,
+      sound: false,
+      badge: false,
+    });
+
+    const granted = await requestPermission();
+
+    expect(granted).toBe(true);
+    expect(PushNotificationIOS.requestPermissions).toHaveBeenCalledWith({
+      alert: true,
+      badge: false,
+      sound: true,
+    });
+  });
+
+  it('does not notify under threshold', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-20',
+      usageSeconds: 790,
+      dailyLimitSeconds: 1000,
+    });
+
+    expect(PushNotificationIOS.addNotificationRequest).not.toHaveBeenCalled();
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('sends one notification at 80% and deduplicates on same day', async () => {
+    (AsyncStorage.getItem as jest.Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('already-sent');
+
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-20',
+      usageSeconds: 800,
+      dailyLimitSeconds: 1000,
+    });
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-20',
+      usageSeconds: 850,
+      dailyLimitSeconds: 1000,
+    });
+
+    expect(PushNotificationIOS.addNotificationRequest).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.getItem).toHaveBeenNthCalledWith(
+      1,
+      'usage-warning:contract-1:2026-02-20:80',
+    );
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends one notification at 90%', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-20',
+      usageSeconds: 900,
+      dailyLimitSeconds: 1000,
+    });
+
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith(
+      'usage-warning:contract-1:2026-02-20:90',
+    );
+    expect(PushNotificationIOS.addNotificationRequest).toHaveBeenCalledTimes(1);
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies again when date changes', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-20',
+      usageSeconds: 800,
+      dailyLimitSeconds: 1000,
+    });
+    await notifyIfThresholdReached({
+      contractId: 'contract-1',
+      localDate: '2026-02-21',
+      usageSeconds: 800,
+      dailyLimitSeconds: 1000,
+    });
+
+    expect(PushNotificationIOS.addNotificationRequest).toHaveBeenCalledTimes(2);
+    expect(AsyncStorage.getItem).toHaveBeenNthCalledWith(
+      1,
+      'usage-warning:contract-1:2026-02-20:80',
+    );
+    expect(AsyncStorage.getItem).toHaveBeenNthCalledWith(
+      2,
+      'usage-warning:contract-1:2026-02-21:80',
+    );
+  });
+});

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -2436,6 +2436,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - RNCPushNotificationIOS (1.12.0):
+    - React-Core
   - RNGestureHandler (2.30.0):
     - boost
     - DoubleConversion
@@ -2727,6 +2729,7 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - SocketRocket (~> 0.7.1)
@@ -2896,6 +2899,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNCPushNotificationIOS:
+    :path: "../node_modules/@react-native-community/push-notification-ios"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
@@ -2913,7 +2918,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 8642d8f14a548ab718ec112e9bebdfdd154138b5
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 22bf66112da540a7d40e536366ddd8557934fca1
   RCTRequired: a0ed4dc41b35f79fbb6d8ba320e06882a8c792cf
   RCTTypeSafety: 59a046ff1e602409a86b89fcd6edff367a5b14af
@@ -2980,6 +2985,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 374f1c9242fbdd673b460d358b33860c0cc9d926
   ReactCommon: 25c7f94aee74ddd93a8287756a8ac0830a309544
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
+  RNCPushNotificationIOS: 85957a0534fd1309b4c028ccbe5b1baf9ab5cf57
   RNGestureHandler: f97d19585553412302394c42495cdaf499589d34
   RNScreens: afaf526a9c804c3b4503f950cf3e67ed81e29ada
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/mobile/ios/mobile/AppDelegate.swift
+++ b/mobile/ios/mobile/AppDelegate.swift
@@ -1,10 +1,11 @@
 import UIKit
+import UserNotifications
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
   var window: UIWindow?
 
   var reactNativeDelegate: ReactNativeDelegate?
@@ -28,8 +29,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       in: window,
       launchOptions: launchOptions
     )
+    UNUserNotificationCenter.current().delegate = self
 
     return true
+  }
+
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner, .list, .sound])
   }
 }
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/push-notification-ios": "^1.12.0",
         "@react-native/new-app-screen": "0.82.0",
         "@react-navigation/native": "^7.1.28",
         "@react-navigation/native-stack": "^7.12.0",
@@ -2969,6 +2970,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/push-notification-ios": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/push-notification-ios/-/push-notification-ios-1.12.0.tgz",
+      "integrity": "sha512-nu6ctimVlK4E3id3QHs9yZJ4vCP5UG3lRaBvSboJZ2IWU0XROcIJnNVIXsSH7C3hTlb84lNwPWir3y/TxRj0oA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.3",
+        "react-native": ">=0.58.4"
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/push-notification-ios": "^1.12.0",
     "@react-native/new-app-screen": "0.82.0",
     "@react-navigation/native": "^7.1.28",
     "@react-navigation/native-stack": "^7.12.0",

--- a/mobile/src/lib/app-context.tsx
+++ b/mobile/src/lib/app-context.tsx
@@ -9,6 +9,7 @@ import React, {
 import type { AppStep, AppInfo, Contract, Profile } from '../types/domain';
 import { mockStore } from './mock-store';
 import { supabase } from './supabase';
+import { notifyIfThresholdReached } from './usage-warning-notifier';
 
 interface AppContextType {
   step: AppStep;
@@ -193,6 +194,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const simulateUsage = useCallback(
     (bundleId: string, seconds: number) => {
       mockStore.simulateUsage(bundleId, seconds);
+      const contract = mockStore.getActiveContract();
+      if (contract) {
+        void notifyIfThresholdReached({
+          contractId: contract.id,
+          localDate: mockStore.getMockLocalDate(),
+          usageSeconds: mockStore.getTodayTotalUsage(),
+          dailyLimitSeconds: contract.dailyLimitSeconds,
+        }).catch(error => {
+          console.warn('Failed to send usage warning notification:', error);
+        });
+      }
       refreshContract();
     },
     [refreshContract],

--- a/mobile/src/lib/usage-warning-notifier.ts
+++ b/mobile/src/lib/usage-warning-notifier.ts
@@ -1,0 +1,82 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import PushNotificationIOS from '@react-native-community/push-notification-ios';
+import { Platform } from 'react-native';
+
+const WARNING_THRESHOLDS = [0.8, 0.9] as const;
+const STORAGE_PREFIX = 'usage-warning';
+
+type NotifyIfThresholdReachedParams = {
+  contractId: string;
+  localDate: string;
+  usageSeconds: number;
+  dailyLimitSeconds: number;
+};
+
+function buildDedupeKey(
+  contractId: string,
+  localDate: string,
+  threshold: number,
+): string {
+  const thresholdPercent = Math.round(threshold * 100);
+  return `${STORAGE_PREFIX}:${contractId}:${localDate}:${thresholdPercent}`;
+}
+
+function buildNotificationId(contractId: string, threshold: number): string {
+  const thresholdPercent = Math.round(threshold * 100);
+  return `${contractId}-${thresholdPercent}-${Date.now()}`;
+}
+
+export async function requestPermission(): Promise<boolean> {
+  if (Platform.OS !== 'ios') {
+    return false;
+  }
+
+  const result = await PushNotificationIOS.requestPermissions({
+    alert: true,
+    badge: false,
+    sound: true,
+  });
+  return Boolean(result.alert || result.sound || result.badge);
+}
+
+export async function notifyIfThresholdReached({
+  contractId,
+  localDate,
+  usageSeconds,
+  dailyLimitSeconds,
+}: NotifyIfThresholdReachedParams): Promise<void> {
+  if (Platform.OS !== 'ios') {
+    return;
+  }
+  if (dailyLimitSeconds <= 0) {
+    return;
+  }
+
+  const usageRatio = usageSeconds / dailyLimitSeconds;
+  const reachedThreshold = [...WARNING_THRESHOLDS]
+    .reverse()
+    .find(threshold => usageRatio >= threshold);
+  if (!reachedThreshold) {
+    return;
+  }
+
+  const dedupeKey = buildDedupeKey(contractId, localDate, reachedThreshold);
+  const alreadyNotified = await AsyncStorage.getItem(dedupeKey);
+  if (alreadyNotified) {
+    return;
+  }
+
+  const thresholdPercent = Math.round(reachedThreshold * 100);
+  PushNotificationIOS.addNotificationRequest({
+    id: buildNotificationId(contractId, reachedThreshold),
+    title: '利用時間の上限が近づいています',
+    body: `今日の利用時間が${thresholdPercent}%に到達しました。`,
+    threadId: `usage-warning-${contractId}`,
+    userInfo: {
+      contractId,
+      localDate,
+      thresholdPercent,
+    },
+  });
+  await AsyncStorage.setItem(dedupeKey, new Date().toISOString());
+}

--- a/mobile/src/screens/PermissionScreen.tsx
+++ b/mobile/src/screens/PermissionScreen.tsx
@@ -9,6 +9,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useApp } from '../lib/app-context';
 import { colors, spacing, borderRadius } from '../lib/theme';
+import { requestPermission as requestNotificationPermission } from '../lib/usage-warning-notifier';
 
 function PermissionItem({
   label,
@@ -32,6 +33,14 @@ export function PermissionScreen(): React.JSX.Element {
 
   const handleGrant = async () => {
     setIsGranting(true);
+    try {
+      const granted = await requestNotificationPermission();
+      if (!granted) {
+        console.warn('Notification permission denied or unavailable');
+      }
+    } catch (error) {
+      console.warn('Failed to request notification permission:', error);
+    }
     await new Promise<void>(resolve => setTimeout(resolve, 1200));
     setGranted(true);
     setIsGranting(false);

--- a/mobile/src/screens/PermissionScreen.tsx
+++ b/mobile/src/screens/PermissionScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -31,16 +31,21 @@ export function PermissionScreen(): React.JSX.Element {
   const [isGranting, setIsGranting] = useState(false);
   const [granted, setGranted] = useState(false);
 
+  useEffect(() => {
+    void (async () => {
+      try {
+        const grantedNotification = await requestNotificationPermission();
+        if (!grantedNotification) {
+          console.warn('Notification permission denied or unavailable');
+        }
+      } catch (error) {
+        console.warn('Failed to request notification permission:', error);
+      }
+    })();
+  }, []);
+
   const handleGrant = async () => {
     setIsGranting(true);
-    try {
-      const granted = await requestNotificationPermission();
-      if (!granted) {
-        console.warn('Notification permission denied or unavailable');
-      }
-    } catch (error) {
-      console.warn('Failed to request notification permission:', error);
-    }
     await new Promise<void>(resolve => setTimeout(resolve, 1200));
     setGranted(true);
     setIsGranting(false);


### PR DESCRIPTION
## What
- Added iOS local warning notifications for usage thresholds (80%/90%) with per-day dedupe
- Integrated threshold checks into usage simulation flow in app context
- Added notification permission request flow on permission screen (auto prompt on screen open)
- Enabled foreground notification presentation in iOS AppDelegate
- Added tests for notifier logic and app-context notification trigger

## Why
- Notify users before daily limit exceeds while avoiding spam
- Make warning behavior testable in current mock usage flow
- Ensure actual iOS banner is visible while app is foregrounded

## Check Lists
- [x] Worked well on local environment
- [x] Tests passed

## ScreenShot (if you need)
<img width="391" height="245" alt="Screenshot 2026-02-20 at 12 55 02" src="https://github.com/user-attachments/assets/5fc787b7-a246-4d56-9faf-ddbee7749eb2" />
<img width="390" height="156" alt="Screenshot 2026-02-20 at 12 55 08" src="https://github.com/user-attachments/assets/b8467015-5db8-49e4-8af6-c5a2af3ca3d8" />


## Related Issues
Closes #29