### PR TITLE
feat: add lock-app UI demo

### DIFF
--- a/lock-app/LockApp.xcodeproj/project.pbxproj
+++ b/lock-app/LockApp.xcodeproj/project.pbxproj
@@ -7,12 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8CE491482F48D15E003CEFE2 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE491462F48D15E003CEFE2 /* MainView.swift */; };
+		8CE491492F48D15E003CEFE2 /* LockManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE491452F48D15E003CEFE2 /* LockManager.swift */; };
+		8CE4914A2F48D15E003CEFE2 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE491472F48D15E003CEFE2 /* SettingsView.swift */; };
 		A11111110000000000000001 /* LockAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12222220000000000000001 /* LockAppApp.swift */; };
 		A11111110000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12222220000000000000002 /* ContentView.swift */; };
 		A11111110000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A12222220000000000000004 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		8CE491452F48D15E003CEFE2 /* LockManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockManager.swift; sourceTree = "<group>"; };
+		8CE491462F48D15E003CEFE2 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		8CE491472F48D15E003CEFE2 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		A12222220000000000000001 /* LockAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockAppApp.swift; sourceTree = "<group>"; };
 		A12222220000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A12222220000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -42,6 +48,9 @@
 		A15555550000000000000002 /* LockApp */ = {
 			isa = PBXGroup;
 			children = (
+				8CE491452F48D15E003CEFE2 /* LockManager.swift */,
+				8CE491462F48D15E003CEFE2 /* MainView.swift */,
+				8CE491472F48D15E003CEFE2 /* SettingsView.swift */,
 				A12222220000000000000001 /* LockAppApp.swift */,
 				A12222220000000000000002 /* ContentView.swift */,
 				A12222220000000000000003 /* Info.plist */,
@@ -127,6 +136,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8CE491482F48D15E003CEFE2 /* MainView.swift in Sources */,
+				8CE491492F48D15E003CEFE2 /* LockManager.swift in Sources */,
+				8CE4914A2F48D15E003CEFE2 /* SettingsView.swift in Sources */,
 				A11111110000000000000001 /* LockAppApp.swift in Sources */,
 				A11111110000000000000002 /* ContentView.swift in Sources */,
 			);
@@ -261,14 +273,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6MZBUNDJGM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LockApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Lock App";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = arm64;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -276,7 +288,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.yohaku.lockapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yohakuyoafjalkfjsf.lockapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -291,14 +303,14 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6MZBUNDJGM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LockApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Lock App";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = arm64;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -306,7 +318,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.yohaku.lockapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yohakuyoafjalkfjsf.lockapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/lock-app/LockApp/LockAppApp.swift
+++ b/lock-app/LockApp/LockAppApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct LockAppApp: App {
     var body: some Scene {
         WindowGroup {
-            LockScreenView()
+            MainView()
         }
     }
 }

--- a/lock-app/LockApp/LockManager.swift
+++ b/lock-app/LockApp/LockManager.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Combine
+
+class LockManager: ObservableObject {
+    static let shared = LockManager()
+
+    private let defaults = UserDefaults.standard
+    private let usageKey = "lockapp.usage_seconds"
+    private let limitKey = "lockapp.limit_seconds"
+    private let dateKey = "lockapp.date"
+
+    @Published var usageSeconds: Int = 0
+    @Published var limitSeconds: Int = 3600 // Default: 1 hour
+    @Published var isLocked: Bool = false
+    @Published var currentDate: String = ""
+
+    private init() {
+        loadState()
+        checkDateChange()
+    }
+
+    private func loadState() {
+        usageSeconds = defaults.integer(forKey: usageKey)
+        limitSeconds = defaults.integer(forKey: limitKey)
+        if limitSeconds == 0 {
+            limitSeconds = 3600 // Default 1 hour
+        }
+        currentDate = defaults.string(forKey: dateKey) ?? getTodayString()
+        updateLockStatus()
+    }
+
+    private func saveState() {
+        defaults.set(usageSeconds, forKey: usageKey)
+        defaults.set(limitSeconds, forKey: limitKey)
+        defaults.set(currentDate, forKey: dateKey)
+    }
+
+    private func getTodayString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    private func checkDateChange() {
+        let today = getTodayString()
+        if currentDate != today {
+            // New day - reset usage
+            usageSeconds = 0
+            currentDate = today
+            isLocked = false
+            saveState()
+        }
+    }
+
+    private func updateLockStatus() {
+        isLocked = usageSeconds >= limitSeconds
+    }
+
+    // MARK: - Public Methods
+
+    func setLimit(seconds: Int) {
+        limitSeconds = max(60, seconds) // Minimum 1 minute
+        saveState()
+        updateLockStatus()
+    }
+
+    func setLimit(minutes: Int) {
+        setLimit(seconds: minutes * 60)
+    }
+
+    func addUsage(seconds: Int) {
+        checkDateChange()
+        usageSeconds += seconds
+        saveState()
+        updateLockStatus()
+    }
+
+    func simulateUsage(minutes: Int) {
+        addUsage(seconds: minutes * 60)
+    }
+
+    func resetUsage() {
+        usageSeconds = 0
+        isLocked = false
+        saveState()
+    }
+
+    func resetAll() {
+        usageSeconds = 0
+        limitSeconds = 3600
+        currentDate = getTodayString()
+        isLocked = false
+        saveState()
+    }
+
+    // MARK: - Formatted Values
+
+    var usageFormatted: String {
+        let hours = usageSeconds / 3600
+        let minutes = (usageSeconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var limitFormatted: String {
+        let hours = limitSeconds / 3600
+        let minutes = (limitSeconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var remainingSeconds: Int {
+        return max(0, limitSeconds - usageSeconds)
+    }
+
+    var remainingFormatted: String {
+        let remaining = remainingSeconds
+        let hours = remaining / 3600
+        let minutes = (remaining % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
+    }
+
+    var progress: Double {
+        guard limitSeconds > 0 else { return 0 }
+        return min(1.0, Double(usageSeconds) / Double(limitSeconds))
+    }
+}

--- a/lock-app/LockApp/MainView.swift
+++ b/lock-app/LockApp/MainView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct MainView: View {
+    @StateObject private var lockManager = LockManager.shared
+    @State private var showSettings = false
+
+    var body: some View {
+        if lockManager.isLocked {
+            LockScreenView()
+                .overlay(
+                    Button(action: { showSettings = true }) {
+                        Image(systemName: "gearshape.fill")
+                            .foregroundColor(.gray.opacity(0.5))
+                            .padding()
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.top, 60)
+                    .padding(.leading, 20)
+                )
+                .sheet(isPresented: $showSettings) {
+                    SettingsView()
+                }
+        } else {
+            UnlockedView()
+                .sheet(isPresented: $showSettings) {
+                    SettingsView()
+                }
+        }
+    }
+}
+
+struct UnlockedView: View {
+    @StateObject private var lockManager = LockManager.shared
+    @State private var showSettings = false
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                // App icon
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.purple.opacity(0.5),
+                                    Color.pink.opacity(0.5),
+                                    Color.orange.opacity(0.5)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 72, height: 72)
+
+                    Image(systemName: "camera.fill")
+                        .font(.system(size: 32))
+                        .foregroundColor(.white)
+                }
+                .padding(.bottom, 8)
+
+                Text("Instagram")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.white)
+
+                // Status
+                VStack(spacing: 12) {
+                    Text("App is Unlocked")
+                        .font(.system(size: 24, weight: .semibold))
+                        .foregroundColor(.green)
+
+                    // Progress bar
+                    GeometryReader { geometry in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(height: 8)
+
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.blue)
+                                .frame(width: geometry.size.width * lockManager.progress, height: 8)
+                        }
+                    }
+                    .frame(height: 8)
+                    .padding(.horizontal, 40)
+
+                    HStack {
+                        Text("Used: \(lockManager.usageFormatted)")
+                            .foregroundColor(.gray)
+                        Spacer()
+                        Text("Limit: \(lockManager.limitFormatted)")
+                            .foregroundColor(.gray)
+                    }
+                    .font(.system(size: 14))
+                    .padding(.horizontal, 40)
+
+                    Text("Remaining: \(lockManager.remainingFormatted)")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.blue)
+                }
+                .padding(.top, 16)
+
+                Spacer()
+
+                // Settings button
+                Button(action: { showSettings = true }) {
+                    HStack {
+                        Image(systemName: "gearshape.fill")
+                        Text("Settings")
+                    }
+                    .font(.system(size: 16))
+                    .foregroundColor(.blue)
+                    .padding()
+                }
+            }
+            .padding(.top, 80)
+            .padding(.bottom, 40)
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+        }
+    }
+}
+
+#Preview("Unlocked") {
+    UnlockedView()
+}
+
+#Preview("Main View") {
+    MainView()
+}

--- a/lock-app/LockApp/SettingsView.swift
+++ b/lock-app/LockApp/SettingsView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @StateObject private var lockManager = LockManager.shared
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var limitMinutes: String = ""
+    @State private var simulateMinutes: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                // Current Status
+                Section(header: Text("Current Status")) {
+                    HStack {
+                        Text("Usage")
+                        Spacer()
+                        Text(lockManager.usageFormatted)
+                            .foregroundColor(.gray)
+                    }
+
+                    HStack {
+                        Text("Limit")
+                        Spacer()
+                        Text(lockManager.limitFormatted)
+                            .foregroundColor(.gray)
+                    }
+
+                    HStack {
+                        Text("Remaining")
+                        Spacer()
+                        Text(lockManager.remainingFormatted)
+                            .foregroundColor(lockManager.isLocked ? .red : .green)
+                    }
+
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        Text(lockManager.isLocked ? "LOCKED" : "Unlocked")
+                            .fontWeight(.semibold)
+                            .foregroundColor(lockManager.isLocked ? .red : .green)
+                    }
+                }
+
+                // Set Limit
+                Section(header: Text("Set Daily Limit")) {
+                    HStack {
+                        Text("Minutes")
+                        TextField("e.g. 60", text: $limitMinutes)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    Button("Apply Limit") {
+                        if let minutes = Int(limitMinutes), minutes > 0 {
+                            lockManager.setLimit(minutes: minutes)
+                            limitMinutes = ""
+                        }
+                    }
+                    .disabled(limitMinutes.isEmpty || Int(limitMinutes) == nil)
+                }
+
+                // Simulate Usage (for testing)
+                Section(header: Text("Simulate Usage (Testing)")) {
+                    HStack {
+                        Text("Add Minutes")
+                        TextField("e.g. 30", text: $simulateMinutes)
+                            .keyboardType(.numberPad)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    Button("Add Usage") {
+                        if let minutes = Int(simulateMinutes), minutes > 0 {
+                            lockManager.simulateUsage(minutes: minutes)
+                            simulateMinutes = ""
+                        }
+                    }
+                    .disabled(simulateMinutes.isEmpty || Int(simulateMinutes) == nil)
+
+                    Button("Quick Add 30 min") {
+                        lockManager.simulateUsage(minutes: 30)
+                    }
+
+                    Button("Quick Add 1 hour") {
+                        lockManager.simulateUsage(minutes: 60)
+                    }
+                }
+
+                // Reset
+                Section(header: Text("Reset")) {
+                    Button("Reset Today's Usage") {
+                        lockManager.resetUsage()
+                    }
+                    .foregroundColor(.orange)
+
+                    Button("Reset All Settings") {
+                        lockManager.resetAll()
+                    }
+                    .foregroundColor(.red)
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## What
- Add LockManager to manage usage and lock status
- Add MainView to switch between locked/unlocked states
- Add SettingsView for testing and configuration
- Support daily limit and usage simulation
- Auto-reset usage on new day

## Why
- Provide a demo app for lock screen UI
- Allow testing of lock/unlock flow
- Foundation for future Screen Time API integration

## Check Lists
[ ] Worked well on local environment
[ ] Tests passed

## ScreenShot (if you need)

## Related Issues