### PR TITLE
fix: harden payment verification and Supabase RPC authorization

### DIFF
--- a/mobile/__tests__/app-context.contract-flow.test.tsx
+++ b/mobile/__tests__/app-context.contract-flow.test.tsx
@@ -114,7 +114,7 @@ function ContractCreationHarness({ onCreated }: HarnessProps) {
 
   useEffect(() => {
     if (!profile || selectedApps.length === 0) return;
-    void createContract(5400, 500).then(onCreated);
+    void createContract(5400, 500, 'pi_test_contract').then(onCreated);
   }, [createContract, onCreated, profile, selectedApps]);
 
   return null;

--- a/mobile/__tests__/app-context.notifications.test.tsx
+++ b/mobile/__tests__/app-context.notifications.test.tsx
@@ -136,7 +136,7 @@ function UsageSimulationHarness() {
     didSimulateRef.current = true;
 
     const app = selectedApps[0];
-    void createContract(3600, 500).then(() => {
+    void createContract(3600, 500, 'pi_test_notifications').then(() => {
       simulateUsage(app.bundleId, 1800);
     });
   }, [profile, selectedApps, setSelectedApps, createContract, simulateUsage]);

--- a/mobile/src/lib/app-context.tsx
+++ b/mobile/src/lib/app-context.tsx
@@ -51,6 +51,7 @@ interface AppContextType {
   createContract: (
     dailyLimitSeconds: number,
     penaltyPerDay: number,
+    paymentIntentId: string,
   ) => Promise<boolean>;
   activeContract: Contract | null;
   refreshContract: () => void;
@@ -275,9 +276,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const createContract = useCallback(
-    async (dailyLimitSeconds: number, penaltyPerDay: number) => {
+    async (
+      dailyLimitSeconds: number,
+      penaltyPerDay: number,
+      paymentIntentId: string,
+    ) => {
       if (selectedApps.length === 0) {
         console.error('[createContract] No selected apps');
+        return false;
+      }
+      if (!paymentIntentId) {
+        console.error('[createContract] Missing paymentIntentId');
         return false;
       }
 
@@ -312,6 +321,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
                 name: app.name,
                 category: app.category,
               })),
+              paymentIntentId,
               contractDays: 7,
               clientNowIso,
               clientLocalDate,
@@ -587,10 +597,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       } else {
         console.warn('Failed to record violation via Edge Function:', error);
       }
-      const result = mockStore.recordViolation(activeContract.id);
-      console.warn('Falling back to local mock violation record');
-      refreshContract();
-      return result !== null;
+      return false;
     }
   }, [
     activeContract,

--- a/mobile/src/screens/ConfirmContractScreen.tsx
+++ b/mobile/src/screens/ConfirmContractScreen.tsx
@@ -86,8 +86,8 @@ export function ConfirmContractScreen(): React.JSX.Element {
             apikey: env.supabaseAnonKey,
           },
           body: JSON.stringify({
-            amount: pendingContractData.depositTotal,
-            currency: 'jpy',
+            penaltyPerDay: pendingContractData.penaltyPerDay,
+            contractDays: 7,
           }),
         },
       );
@@ -122,7 +122,12 @@ export function ConfirmContractScreen(): React.JSX.Element {
         return;
       }
 
-      const { clientSecret } = await paymentIntentResponse.json();
+      const { clientSecret, paymentIntentId } =
+        await paymentIntentResponse.json();
+      if (!clientSecret || !paymentIntentId) {
+        setError('決済の初期化情報が不正です');
+        return;
+      }
 
       const { error: confirmError } = await confirmPayment(clientSecret, {
         paymentMethodType: 'Card',
@@ -139,6 +144,7 @@ export function ConfirmContractScreen(): React.JSX.Element {
       const created = await createContract(
         pendingContractData.dailyLimitSeconds,
         pendingContractData.penaltyPerDay,
+        paymentIntentId,
       );
 
       if (!created) {

--- a/supabase/functions/create-contract/index.ts
+++ b/supabase/functions/create-contract/index.ts
@@ -15,6 +15,7 @@ type CreateContractBody = {
   dailyLimitSeconds: number
   penaltyPerDay: number
   depositTotal: number
+  paymentIntentId: string
   selectedApps: Array<{
     bundleId: string
     name: string
@@ -45,8 +46,9 @@ Deno.serve(async (req) => {
     const supabaseUrl = Deno.env.get("SUPABASE_URL")
     const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")
     const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+    const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY")
 
-    if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceRoleKey) {
+    if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceRoleKey || !stripeSecretKey) {
       return new Response(
         JSON.stringify({ error: "missing_supabase_env" }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } },
@@ -80,6 +82,7 @@ Deno.serve(async (req) => {
       dailyLimitSeconds,
       penaltyPerDay,
       depositTotal,
+      paymentIntentId,
       selectedApps,
       contractDays = 7,
       clientNowIso,
@@ -106,6 +109,12 @@ Deno.serve(async (req) => {
     if (depositTotal !== penaltyPerDay * 7) {
       return new Response(
         JSON.stringify({ error: "deposit_mismatch" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      )
+    }
+    if (!paymentIntentId || !paymentIntentId.startsWith("pi_")) {
+      return new Response(
+        JSON.stringify({ error: "invalid_payment_intent_id" }),
         { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
       )
     }
@@ -182,6 +191,44 @@ Deno.serve(async (req) => {
           },
         }),
         { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      )
+    }
+
+    const paymentIntentResponse = await fetch(
+      `https://api.stripe.com/v1/payment_intents/${paymentIntentId}`,
+      {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${stripeSecretKey}`,
+        },
+      },
+    )
+    if (!paymentIntentResponse.ok) {
+      return new Response(
+        JSON.stringify({ error: "failed_to_verify_payment_intent" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      )
+    }
+    const paymentIntent = await paymentIntentResponse.json() as {
+      status?: string
+      amount?: number
+      currency?: string
+      metadata?: Record<string, string>
+    }
+    const metadataUserId = paymentIntent.metadata?.user_id ?? ""
+    const metadataPenaltyPerDay = Number(paymentIntent.metadata?.penalty_per_day ?? "")
+    const metadataContractDays = Number(paymentIntent.metadata?.contract_days ?? "")
+    const isPaymentValid =
+      paymentIntent.status === "succeeded" &&
+      paymentIntent.amount === depositTotal &&
+      paymentIntent.currency === "jpy" &&
+      metadataUserId === userId &&
+      metadataPenaltyPerDay === penaltyPerDay &&
+      metadataContractDays === contractDays
+    if (!isPaymentValid) {
+      return new Response(
+        JSON.stringify({ error: "payment_verification_failed" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
       )
     }
 

--- a/supabase/functions/create-payment-intent/index.ts
+++ b/supabase/functions/create-payment-intent/index.ts
@@ -7,8 +7,8 @@ const corsHeaders = {
 }
 
 type CreatePaymentIntentBody = {
-  amount?: number
-  currency?: string
+  penaltyPerDay?: number
+  contractDays?: number
 }
 
 Deno.serve(async (req) => {
@@ -58,8 +58,29 @@ Deno.serve(async (req) => {
     }
 
     const body = await req.json() as CreatePaymentIntentBody
-    const amount = body.amount ?? 3500 // Default: 3500 yen (7 days * 500 yen)
-    const currency = body.currency ?? "jpy"
+    const penaltyPerDay = body.penaltyPerDay
+    const contractDays = body.contractDays ?? 7
+
+    if (
+      !penaltyPerDay ||
+      penaltyPerDay < 500 ||
+      penaltyPerDay > 2000 ||
+      penaltyPerDay % 100 !== 0
+    ) {
+      return new Response(
+        JSON.stringify({ error: "invalid_penalty_per_day" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      )
+    }
+    if (contractDays !== 7) {
+      return new Response(
+        JSON.stringify({ error: "invalid_contract_days" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      )
+    }
+
+    const amount = penaltyPerDay * contractDays
+    const currency = "jpy"
 
     // Create PaymentIntent via Stripe API
     const stripeResponse = await fetch("https://api.stripe.com/v1/payment_intents", {
@@ -72,6 +93,8 @@ Deno.serve(async (req) => {
         amount: amount.toString(),
         currency: currency,
         "metadata[user_id]": authData.user.id,
+        "metadata[penalty_per_day]": penaltyPerDay.toString(),
+        "metadata[contract_days]": contractDays.toString(),
         "automatic_payment_methods[enabled]": "true",
       }).toString(),
     })

--- a/supabase/migrations/20260222001208_harden_record_violation_rpc.sql
+++ b/supabase/migrations/20260222001208_harden_record_violation_rpc.sql
@@ -1,0 +1,2 @@
+revoke execute on function public.record_violation(uuid, uuid, date, timestamptz) from authenticated;
+grant execute on function public.record_violation(uuid, uuid, date, timestamptz) to service_role;


### PR DESCRIPTION
## What
- Hardened payment creation so amount/currency are derived server-side in create-payment-intent
- Added Stripe PaymentIntent verification in create-contract before contract creation
- Required paymentIntentId in app contract creation flow and wired it from confirm step
- Removed local mock fallback when record-violation Edge Function fails (fail-closed)
- Added DB migration to restrict public.record_violation(...) execute permission to service_role
- Updated app-context tests for new createContract signature

## Why
- Prevent client-side tampering of payment amount/currency
- Ensure contracts are only persisted after validated successful payment
- Tighten RPC access boundary to stop direct execution by anon/authenticated
- Keep violation/accounting state consistent with backend source of truth

## Check Lists
[x] Worked well on local environment
[x] Tests passed

## ScreenShot (if you need)
N/A

## Related Issues
Closes #56
