### PR TITLE
fix: remove obsolete dashboard daily reset action

### DIFF
--- a/mobile/src/lib/app-context.tsx
+++ b/mobile/src/lib/app-context.tsx
@@ -57,7 +57,6 @@ interface AppContextType {
   refreshContract: () => void;
   simulateUsage: (bundleId: string, seconds: number) => void;
   triggerViolation: () => Promise<boolean>;
-  resetDailyShield: () => void;
   advanceMockDay: () => void;
 }
 
@@ -606,11 +605,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
     syncContractFinancials,
   ]);
 
-  const resetDailyShield = useCallback(() => {
-    mockStore.resetDailyShield();
-    refreshContract();
-  }, [refreshContract]);
-
   const advanceMockDay = useCallback(() => {
     mockStore.advanceToNextDay();
     refreshContract();
@@ -640,7 +634,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
         refreshContract,
         simulateUsage,
         triggerViolation,
-        resetDailyShield,
         advanceMockDay,
       }}
     >

--- a/mobile/src/lib/mock-store.ts
+++ b/mobile/src/lib/mock-store.ts
@@ -427,10 +427,6 @@ class MockStore {
     this.shieldActive = this.getTodayViolation(contractId) !== null;
   }
 
-  resetDailyShield(): void {
-    this.shieldActive = false;
-  }
-
   // Check if contract has expired
   checkContractExpiry(): void {
     const contract = this.getActiveContract();

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -71,14 +71,12 @@ function ActiveDashboard({
   contract,
   simulateUsage,
   triggerViolation,
-  resetDailyShield,
   advanceMockDay,
   logout,
 }: {
   contract: Contract;
   simulateUsage: (bundleId: string, seconds: number) => void;
   triggerViolation: () => Promise<boolean>;
-  resetDailyShield: () => void;
   advanceMockDay: () => void;
   logout: () => void;
 }) {
@@ -98,7 +96,6 @@ function ActiveDashboard({
   const violationDays = mockStore.getViolationDaysCount(contract.id);
   const balance = mockStore.getContractBalance(contract.id);
   const totalPenalty = mockStore.getTotalPenalty(contract.id);
-  const isShielded = mockStore.isShieldActive();
   const mockLocalDate = mockStore.getMockLocalDate();
   const startLocalDate = toLocalDateString(new Date(contract.startAt));
   const completedDays = Math.max(
@@ -305,14 +302,6 @@ function ActiveDashboard({
                   <Text style={styles.dayAdvanceText}>次の日へ進める</Text>
                 </TouchableOpacity>
               </View>
-              {isShielded && (
-                <TouchableOpacity
-                  style={styles.resetButton}
-                  onPress={resetDailyShield}
-                >
-                  <Text style={styles.resetText}>日次リセット</Text>
-                </TouchableOpacity>
-              )}
             </View>
           )}
         </View>
@@ -407,7 +396,6 @@ export function DashboardScreen(): React.JSX.Element {
     refreshContract,
     simulateUsage,
     triggerViolation,
-    resetDailyShield,
     advanceMockDay,
     logout,
     setStep,
@@ -450,7 +438,6 @@ export function DashboardScreen(): React.JSX.Element {
         contract={contract}
         simulateUsage={simulateUsage}
         triggerViolation={triggerViolation}
-        resetDailyShield={resetDailyShield}
         advanceMockDay={advanceMockDay}
         logout={logout}
       />
@@ -727,18 +714,6 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
   },
   dayAdvanceText: {
-    fontSize: 13,
-    color: colors.text,
-  },
-  resetButton: {
-    backgroundColor: colors.background,
-    borderRadius: borderRadius.sm,
-    paddingVertical: spacing.sm,
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  resetText: {
     fontSize: 13,
     color: colors.text,
   },


### PR DESCRIPTION
## What
- Removed the obsolete dashboard daily reset button from simulator section
- Removed `resetDailyShield` from app context API and provider value
- Removed unused `resetDailyShield` method from mock store

## Why
- Daily reset action is no longer required by product behavior and had become dead/legacy control flow

## Check Lists
[x] Worked well on local environment
[x] Tests passed (`npm run mobile:ci`)

## ScreenShot (if you need)
- UI cleanup only (no new visual assets)

## Related Issues
Closes #58
Refs #60