### PR TITLE
fix: polish lock-app and onboarding/payment UI copy

### DIFF
--- a/lock-app/LockApp/ContentView.swift
+++ b/lock-app/LockApp/ContentView.swift
@@ -13,7 +13,7 @@ extension View {
 
 struct LockScreenView: View {
     // アプリ名はここで変更できます
-    let appName: String = "Instagram"
+    let appName: String = "SNS"
 
     var body: some View {
         ZStack {
@@ -23,33 +23,6 @@ struct LockScreenView: View {
 
             VStack(spacing: 0) {
                 Spacer()
-
-                // アプリアイコン（薄暗い）
-                ZStack {
-                    RoundedRectangle(cornerRadius: 16)
-                        .fill(
-                            LinearGradient(
-                                colors: [
-                                    Color.purple.opacity(0.3),
-                                    Color.pink.opacity(0.3),
-                                    Color.orange.opacity(0.3)
-                                ],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 72, height: 72)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16)
-                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                        )
-
-                    // カメラアイコン
-                    Image(systemName: "camera.fill")
-                        .font(.system(size: 32))
-                        .foregroundColor(.white.opacity(0.5))
-                }
-                .padding(.bottom, 16)
 
                 // 砂時計アイコンとアプリ名
                 HStack(spacing: 6) {
@@ -63,50 +36,25 @@ struct LockScreenView: View {
                 }
                 .padding(.bottom, 24)
 
-                // タイトル
-                Text("App Limit")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundColor(.white)
-                    .padding(.bottom, 12)
+                Text("LOCKED")
+                    .font(.system(size: 34, weight: .bold))
+                    .foregroundColor(.red)
+                    .padding(.bottom, 10)
 
-                // メッセージ
-                Text("You've reached your limit for \(appName).")
+                Text("\(appName) は本日の上限に達しました。")
                     .font(.system(size: 17))
                     .foregroundColor(.gray)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 40)
+                    .padding(.bottom, 12)
+
+                Text("少し休んで、また明日落ち着いて使いましょう。")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(.white.opacity(0.88))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 36)
 
                 Spacer()
-
-                // ボタン
-                VStack(spacing: 0) {
-                    Divider()
-                        .background(Color.gray.opacity(0.3))
-
-                    Button(action: {
-                        // 何もしない（OKボタン）
-                    }) {
-                        Text("OK")
-                            .font(.system(size: 20))
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                    }
-
-                    Divider()
-                        .background(Color.gray.opacity(0.3))
-
-                    Button(action: {
-                        // 何もしない（Request More Time）
-                    }) {
-                        Text("Request More Time")
-                            .font(.system(size: 20))
-                            .foregroundColor(.blue)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                    }
-                }
-                .background(Color.black)
             }
         }
         .lockAppStatusBarHidden()

--- a/lock-app/LockApp/MainView.swift
+++ b/lock-app/LockApp/MainView.swift
@@ -2,31 +2,14 @@ import SwiftUI
 
 struct MainView: View {
     @StateObject private var lockManager = LockManager.shared
-    @State private var showSettings = false
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         Group {
             if lockManager.isLocked {
                 LockScreenView()
-                    .overlay(
-                        Button(action: { showSettings = true }) {
-                            Image(systemName: "gearshape.fill")
-                                .foregroundColor(.gray.opacity(0.5))
-                                .padding()
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                        .padding(.top, 60)
-                        .padding(.leading, 20)
-                    )
-                    .sheet(isPresented: $showSettings) {
-                        SettingsView()
-                    }
             } else {
                 UnlockedView()
-                    .sheet(isPresented: $showSettings) {
-                        SettingsView()
-                    }
             }
         }
         .onAppear {
@@ -42,7 +25,6 @@ struct MainView: View {
 
 struct UnlockedView: View {
     @StateObject private var lockManager = LockManager.shared
-    @State private var showSettings = false
 
     var body: some View {
         ZStack {
@@ -74,44 +56,22 @@ struct UnlockedView: View {
                 }
                 .padding(.bottom, 8)
 
-                // App icon (smaller, below checkmark)
-                ZStack {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(
-                            LinearGradient(
-                                colors: [
-                                    Color.purple.opacity(0.5),
-                                    Color.pink.opacity(0.5),
-                                    Color.orange.opacity(0.5)
-                                ],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                        .frame(width: 48, height: 48)
-
-                    Image(systemName: "camera.fill")
-                        .font(.system(size: 20))
-                        .foregroundColor(.white)
-                }
-
-                Text("Instagram")
+                Text("SNS")
                     .font(.system(size: 18, weight: .medium))
                     .foregroundColor(.white)
 
-                // UNLOCKED text
                 Text("UNLOCKED")
                     .font(.system(size: 32, weight: .bold))
                     .foregroundColor(.green)
                     .padding(.top, 8)
 
-                Text("This app is available to use")
+                Text("現在は利用できます")
                     .font(.system(size: 16))
                     .foregroundColor(.gray)
 
                 // Time remaining
                 VStack(spacing: 8) {
-                    Text("Time Remaining Today")
+                    Text("本日の残り時間")
                         .font(.system(size: 14))
                         .foregroundColor(.gray)
 
@@ -126,23 +86,9 @@ struct UnlockedView: View {
                 .cornerRadius(12)
 
                 Spacer()
-
-                // Settings button
-                Button(action: { showSettings = true }) {
-                    HStack {
-                        Image(systemName: "gearshape.fill")
-                        Text("Settings")
-                    }
-                    .font(.system(size: 16))
-                    .foregroundColor(.blue)
-                    .padding()
-                }
             }
             .padding(.top, 60)
             .padding(.bottom, 40)
-        }
-        .sheet(isPresented: $showSettings) {
-            SettingsView()
         }
     }
 }

--- a/mobile/src/screens/CreateContractScreen.tsx
+++ b/mobile/src/screens/CreateContractScreen.tsx
@@ -336,7 +336,8 @@ export function CreateContractScreen(): React.JSX.Element {
             />
           </View>
           <Text style={styles.contractNote}>
-            デポジットは仮預かりです。違反がなければ全額返金されます。
+            デポジットは仮預かりです。{'\n'}
+            ７日後に違反日数分、減額して返金されます。
           </Text>
         </View>
       </ScrollView>

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -339,9 +339,6 @@ function CompletedDashboard({
 
         {/* Completion badge */}
         <View style={styles.completionCard}>
-          <View style={styles.completionIcon}>
-            <Text style={styles.completionIconText}>完</Text>
-          </View>
           <Text style={styles.completionTitle}>契約が完了しました</Text>
           <Text style={styles.completionSubtitle}>
             1週間の取り組み、お疲れさまでした。
@@ -372,9 +369,7 @@ function CompletedDashboard({
               highlight
             />
           </View>
-          <Text style={styles.resultNote}>
-            MVP: 実際の返金処理は行われません
-          </Text>
+          <Text style={styles.resultNote}>最終残高が返金されます。</Text>
         </View>
 
         {/* New contract */}
@@ -732,19 +727,6 @@ const styles = StyleSheet.create({
     borderColor: colors.border,
     alignItems: 'center',
     gap: spacing.md,
-  },
-  completionIcon: {
-    width: 64,
-    height: 64,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.primary,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  completionIconText: {
-    fontSize: 28,
-    fontWeight: '500',
-    color: colors.surface,
   },
   completionTitle: {
     fontSize: 18,

--- a/mobile/src/screens/LoginScreen.tsx
+++ b/mobile/src/screens/LoginScreen.tsx
@@ -34,14 +34,6 @@ export function LoginScreen(): React.JSX.Element {
           <Text style={styles.subtitle}>スマホから、余白を取り戻す</Text>
         </View>
 
-        {/* Message */}
-        <View style={styles.messageBox}>
-          <Text style={styles.messageText}>
-            契約と金銭的コミットメントで{'\n'}
-            スマホ利用をコントロール
-          </Text>
-        </View>
-
         {/* Login button */}
         <View style={styles.buttonContainer}>
           <TouchableOpacity
@@ -59,7 +51,6 @@ export function LoginScreen(): React.JSX.Element {
               <Text style={styles.buttonText}>Sign in with Apple</Text>
             )}
           </TouchableOpacity>
-          <Text style={styles.disclaimer}>MVP: モックログインを使用</Text>
         </View>
       </View>
     </SafeAreaView>
@@ -93,22 +84,6 @@ const styles = StyleSheet.create({
     color: colors.textSecondary,
     textAlign: 'center',
   },
-  messageBox: {
-    width: '100%',
-    backgroundColor: colors.surfaceAlt,
-    borderRadius: borderRadius.md,
-    paddingVertical: spacing.xxl,
-    paddingHorizontal: spacing.xl,
-    marginBottom: 56,
-    borderLeftWidth: 3,
-    borderLeftColor: colors.primary,
-  },
-  messageText: {
-    fontSize: 14,
-    color: colors.textSecondary,
-    textAlign: 'center',
-    lineHeight: 22,
-  },
   buttonContainer: {
     width: '100%',
     alignItems: 'center',
@@ -134,10 +109,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '500',
     color: colors.surface,
-  },
-  disclaimer: {
-    marginTop: spacing.md,
-    fontSize: 12,
-    color: colors.textLight,
   },
 });

--- a/mobile/src/screens/PaymentScreen.tsx
+++ b/mobile/src/screens/PaymentScreen.tsx
@@ -127,7 +127,13 @@ export function PaymentScreen(): React.JSX.Element {
 
           <View style={styles.securityNote}>
             <Text style={styles.securityNoteText}>
-              🔒 カード情報は暗号化されてStripeを通じて安全に処理されます
+              カード情報は暗号化され、Stripeを通じて安全に処理されます。
+            </Text>
+            <Text style={styles.testCardNote}>
+              テスト用: 4242 4242 4242 4242（仮発行クレカ情報）
+            </Text>
+            <Text style={styles.testCardNote}>
+              MM/YY・CVCは任意の値で入力できます。
             </Text>
           </View>
 
@@ -229,6 +235,12 @@ const styles = StyleSheet.create({
   securityNoteText: {
     fontSize: 12,
     color: colors.textMuted,
+    textAlign: 'center',
+  },
+  testCardNote: {
+    marginTop: spacing.xs,
+    fontSize: 12,
+    color: colors.textSecondary,
     textAlign: 'center',
   },
   errorContainer: {

--- a/mobile/src/screens/PermissionScreen.tsx
+++ b/mobile/src/screens/PermissionScreen.tsx
@@ -63,8 +63,8 @@ export function PermissionScreen(): React.JSX.Element {
           </View>
           <Text style={styles.title}>Screen Time 許可</Text>
           <Text style={styles.description}>
-            アプリの使用時間を監視し、制限を適用するために{'\n'}
-            Screen Time APIへのアクセスが必要です。
+            アプリの使用時間を監視し、起動に制限を適用するためにScreen
+            Timeへのアクセスが必要です。
           </Text>
         </View>
 
@@ -109,12 +109,6 @@ export function PermissionScreen(): React.JSX.Element {
               <Text style={styles.buttonText}>許可する</Text>
             )}
           </TouchableOpacity>
-          <View style={styles.helperCard}>
-            <Text style={styles.helperCardText}>
-              許可後に制限対象アプリの選択画面へ進みます
-            </Text>
-          </View>
-          <Text style={styles.disclaimer}>MVP: モックで許可をシミュレート</Text>
         </View>
       </View>
     </SafeAreaView>
@@ -195,20 +189,6 @@ const styles = StyleSheet.create({
     width: '100%',
     alignItems: 'center',
   },
-  helperCard: {
-    width: '100%',
-    marginTop: spacing.md,
-    padding: spacing.md,
-    backgroundColor: colors.surfaceAlt,
-    borderRadius: borderRadius.md,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  helperCardText: {
-    fontSize: 12,
-    color: colors.textMuted,
-    textAlign: 'center',
-  },
   button: {
     width: '100%',
     height: 52,
@@ -239,10 +219,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '500',
     color: colors.surface,
-  },
-  disclaimer: {
-    marginTop: spacing.md,
-    fontSize: 12,
-    color: colors.textLight,
   },
 });


### PR DESCRIPTION
## What
- lock-app の Locked/Unlocked UI を整理し、状態変更導線と不要アイコンを削除
- lock-app の文言を調整（Instagram -> SNS、ロック文言の日本語化）
- mobile 側のログイン/許可/契約作成/支払い/完了画面の文言を要望どおり更新
- payment 画面にテスト用カード注釈（4242 ...）と MM/YY・CVC 任意注記を追加

## Why
- ハッカソン最終調整として、画面文言と UI の一貫性を高め、誤解を生まない表示にするため

## Check Lists
[x] Worked well on local environment
[x] Tests passed

## ScreenShot (if you need)
- N/A

## Related Issues
Closes #62
